### PR TITLE
Add all `possible_values` to network command option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deployed by `regtest-*` features.
 - Add an integration testing framework in `src/tests/integration.rs`. This framework uses
   the `regtest-*` feature to run automated testing with bdk-cli.
+- Add possible values for `network` option to improve help message, and fix typo in doc.
 
 ## [0.5.0]
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -49,7 +49,8 @@ pub struct CliOpts {
         name = "NETWORK",
         short = "n",
         long = "network",
-        default_value = "testnet"
+        default_value = "testnet",
+        possible_values = &["bitcoin", "testnet", "signet", "regtest"]
     )]
     pub network: Network,
     /// Sets the wallet data directory.
@@ -69,7 +70,7 @@ pub enum CliSubCommand {
     ///
     /// These commands can be used to control the backend bitcoin-core node
     /// launched automatically with the `regtest-*` feature sets. The commands issues
-    /// bitcoin-cli rpc calls on the demon, in the background.
+    /// bitcoin-cli rpc calls on the daemon, in the background.
     ///
     /// Feel free to open feature-request in <https://github.com/bitcoindevkit/bdk-cli>
     /// if you need extra rpc calls not covered in the command list.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds all possible values for `network` command option, it now shows a better help message with all valid values. It also updates a typo from `demon` to `daemon` on `Node` command docs.

Fixes #88

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

As described in the issue #88 comments, I went through the commands but did not find other than the network that we could update it to show all its possible values.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk-cli/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
